### PR TITLE
Version 2.2.0

### DIFF
--- a/Processor/ToleranceProcessor.php
+++ b/Processor/ToleranceProcessor.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Talopay_Transfer
+ *
+ * @author TaloPay https://talo.com.ar/
+ * @license OSL-3.0 https://opensource.org/license/osl-3.0.php
+ */
+declare(strict_types = 1);
+
+namespace TaloPay\Transfer\Processor;
+
+use Magento\Framework\DB\TransactionFactory;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
+use Magento\Sales\Model\Order\Invoice;
+use Magento\Sales\Model\Service\InvoiceService;
+use TaloPay\Transfer\Api\ConfigInterface;
+use TaloPay\Transfer\Api\Data\PaymentProcessorResponseInterface;
+use TaloPay\Transfer\Api\NotificationSenderInterface;
+use TaloPay\Transfer\Api\PaymentProcessorInterface;
+
+class ToleranceProcessor implements PaymentProcessorInterface
+{
+    /**
+     * @param ConfigInterface $config
+     * @param InvoiceSender $invoiceSender
+     * @param InvoiceService $invoiceService
+     * @param TransactionFactory $transactionFactory
+     */
+    public function __construct(
+        private readonly ConfigInterface $config,
+        private readonly InvoiceSender $invoiceSender,
+        private readonly InvoiceService $invoiceService,
+        private readonly TransactionFactory $transactionFactory,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(
+        OrderInterface $order,
+        string $paymentId,
+        array $taloPayment,
+        ?PaymentProcessorResponseInterface $previousResult = null
+    ): ?PaymentProcessorResponseInterface {
+        $paymentSuccess = $taloPayment['status'] === 'SUCCESS';
+        if (!$paymentSuccess) {
+            return $previousResult;
+        }
+
+        if ($order->getTotalDue() <= 0) {
+            return $previousResult;
+        }
+
+        $notifyAll = $this->config->getNotificationEmailStatus() === NotificationSenderInterface::STATUS_ON_TRANSACTION;
+        $notifyTotal = $this->config->getNotificationEmailStatus() === NotificationSenderInterface::STATUS_ON_TOTAL;
+
+        // Si hay deuda en el pedido y el estado actual del pago es success se prepara el invoice para
+        // el total de lo adeudado.
+        $diffAmount = $order->getTotalDue();
+        $invoice = $this->invoiceService->prepareInvoice($order);
+        $invoice->setSubtotal($diffAmount);
+        $invoice->setBaseSubtotal($diffAmount);
+        $invoice->setSubtotalInclTax($diffAmount);
+        $invoice->setBaseSubtotalInclTax($diffAmount);
+        $invoice->setGrandTotal($diffAmount);
+        $invoice->setBaseGrandTotal($diffAmount);
+        $invoice->register();
+        $invoice->setState(Invoice::STATE_PAID);
+        $order->getPayment()->pay($invoice);
+
+        $invoice->getExtensionAttributes()
+            ->setDueAmount(0.0)
+            ->setBaseDueAmount(0.0);
+
+        $order->setTotalPaid($invoice->getGrandTotal() + $order->getTotalPaid());
+        $order->setBaseTotalPaid($invoice->getBaseGrandTotal() + $order->getBaseTotalPaid());
+
+        $transaction = $this->transactionFactory->create();
+        $transaction->addObject($invoice);
+        $transaction->addObject($invoice->getOrder());
+        $transaction->save();
+
+        $invoice->getExtensionAttributes()->setDueAmount((float)$order->getTotalDue())
+            ->setBaseDueAmount((float)$order->getBaseTotalDue());
+
+        $this->invoiceSender->send($invoice);
+
+        $previousResult->addComment(__(
+            'The invoice #%1 was generated due to Talo\'s tolerance policy.',
+            $invoice->getIncrementId()
+        ));
+
+        if ($notifyAll ||
+            (float)$order->getTotalDue() === 0.0 && $notifyTotal) {
+            $invoices = $previousResult->getInvoicesToNotify();
+            $invoices[$invoice->getId()] = $invoice;
+            $previousResult->setInvoicesToNotify($invoices);
+        }
+
+        return $previousResult;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "TaloPay Magento 2 Transfer module",
     "type": "magento2-module",
     "license": "OSL-3.0",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "require": {
         "ext-intl": "*",
         "php": "~8.2||~8.3||~8.4",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -63,6 +63,7 @@
         <arguments>
             <argument name="handlers" xsi:type="array">
                 <item name="default" xsi:type="object">TaloPay\Transfer\Processor\PaymentProcessor</item>
+                <item name="tolerance" xsi:type="object">TaloPay\Transfer\Processor\ToleranceProcessor</item>
                 <item name="status" xsi:type="object">TaloPay\Transfer\Processor\StatusProcessor</item>
                 <item name="notification" xsi:type="object">TaloPay\Transfer\Processor\NotificationProcessor</item>
             </argument>

--- a/i18n/es_AR.csv
+++ b/i18n/es_AR.csv
@@ -35,3 +35,4 @@
 "Waiting for payment...","Esperando pago..."
 "Partial payment received. Remaining balance: %1","Pago parcial recibido. Monto restante: %1"
 "The invoice #%1 was been generated with transaction id %2","Se generó la factura #%1 con el id de transacción %2"
+"The invoice #%1 was generated due to Talo\'s tolerance policy.","Se generó la factura #%1 debido a la política de tolerancia de Talo"


### PR DESCRIPTION
Support for tolerance amounts has been added, meaning that if an order wasn't fully paid but Talo reported it as successful because the difference is within that margin, we  create an invoice for the difference with a related note.

This allows the order to change status later if the shipment has been created (preventing orders from being blocked due to non-payment of the original total).