### PR TITLE
Version 2.3.0

### DIFF
--- a/Api/ConfigInterface.php
+++ b/Api/ConfigInterface.php
@@ -28,6 +28,7 @@ interface ConfigInterface
     public const XPATH_ENVIRONMENT = 'environment';
     public const XPATH_INSTRUCTIONS = 'instructions';
     public const XPATH_ORDER_STATUS = 'order_status';
+    public const XPATH_DISPLAY_ACCOUNT = 'success/display_account';
     public const XPATH_PRODUCTION_CLIENT_ID = 'production_credentials/client_id';
     public const XPATH_PRODUCTION_CLIENT_SECRET = 'production_credentials/client_secret';
     public const XPATH_PRODUCTION_USER_ID = 'production_credentials/user_id';
@@ -41,6 +42,10 @@ interface ConfigInterface
     public const XPATH_STATUS_REJECTED = 'status_rejected';
     public const XPATH_TALOPAY_APP_ID = 'app_id';
     public const XPATH_TALOPAY_STORE_ID = 'store_id';
+    public const DISPLAY_ACCOUNT_BOTH = 'both';
+    public const DISPLAY_ACCOUNT_ALIAS = 'alias';
+    public const DISPLAY_ACCOUNT_CVU = 'cvu';
+
 
     /**
      * @param string|null $environment
@@ -53,6 +58,13 @@ interface ConfigInterface
      * @return string
      */
     public function getClientSecret(?string $environment = null);
+
+    /**
+     * Return the setting display account
+     *
+     * @return string
+     */
+    public function getDisplayAccount(): string;
 
     /**
      * @return string

--- a/Block/Payment/View/Instructions.php
+++ b/Block/Payment/View/Instructions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Talopay_Transfer
- * 
+ *
  * @author TaloPay https://talo.com.ar/
  * @license OSL-3.0 https://opensource.org/license/osl-3.0.php
  */
@@ -27,6 +27,7 @@ class Instructions extends Template
      * @param CurrencyInterface $currency
      * @param Session $checkoutSession
      * @param ArrayManager $arrayManager
+     * @param ConfigInterface $config
      * @param array $data
      */
     public function __construct(
@@ -34,55 +35,10 @@ class Instructions extends Template
         readonly private CurrencyInterface $currency,
         readonly private Session $checkoutSession,
         readonly private ArrayManager $arrayManager,
+        readonly private ConfigInterface $config,
         array $data = []
     ) {
         parent::__construct($context, $data);
-    }
-
-    /**
-     * @return array|string
-     */
-    public function getTaloIssuerName()
-    {
-        return $this->getPaymentAdditionalInformation('user_info/full_name', '');
-    }
-
-    /**
-     * @param string $path
-     * @param string|null $defaultValue
-     * @return string|null|array
-     */
-    private function getPaymentAdditionalInformation(string $path, string $defaultValue = null)
-    {
-        $taloData = $this->getPayment()->getAdditionalInformation(ConfigInterface::ORDER_ADDITIONAL_KEY) ?? [];
-        return $this->arrayManager->get($path, $taloData, $defaultValue) ?? $defaultValue;
-    }
-
-    /**
-     * @return false|float|\Magento\Framework\DataObject|OrderPaymentInterface|mixed|null
-     */
-    public function getPayment()
-    {
-        $order = $this->checkoutSession->getLastRealOrder();
-
-        return $order->getPayment();
-    }
-
-    /**
-     * @return array|string
-     */
-    public function getTaloIssuerTaxVatId()
-    {
-        return $this->getPaymentAdditionalInformation('user_info/cuit', '');
-    }
-
-    /**
-     * @return array|string
-     * @throws LocalizedException
-     */
-    public function getTaloQuotes()
-    {
-        return $this->getPaymentAdditionalInformation('quotes', '') ?: [];
     }
 
     /**
@@ -107,6 +63,62 @@ class Instructions extends Template
             }
         }
         return '';
+    }
+
+    /**
+     * @param string $path
+     * @param string|null $defaultValue
+     * @return string|null|array
+     */
+    private function getPaymentAdditionalInformation(string $path, ?string $defaultValue = null)
+    {
+        $taloData = $this->getPayment()->getAdditionalInformation(ConfigInterface::ORDER_ADDITIONAL_KEY) ?? [];
+        return $this->arrayManager->get($path, $taloData, $defaultValue) ?? $defaultValue;
+    }
+
+    /**
+     * @return false|float|\Magento\Framework\DataObject|OrderPaymentInterface|mixed|null
+     */
+    public function getPayment()
+    {
+        $order = $this->checkoutSession->getLastRealOrder();
+
+        return $order->getPayment();
+    }
+
+    /**
+     * @return array|string
+     */
+    public function getTaloIssuerName()
+    {
+        return $this->getPaymentAdditionalInformation('user_info/full_name', '');
+    }
+
+    /**
+     * @return array|string
+     */
+    public function getTaloIssuerTaxVatId()
+    {
+        return $this->getPaymentAdditionalInformation('user_info/cuit', '');
+    }
+
+    /**
+     * @return array|string
+     * @throws LocalizedException
+     */
+    public function getTaloQuotes()
+    {
+        return $this->getPaymentAdditionalInformation('quotes', '') ?: [];
+    }
+
+    /**
+     * Return the config to display account
+     *
+     * @return string
+     */
+    public function isDisplayAccount()
+    {
+        return $this->config->getDisplayAccount();
     }
 
     /**

--- a/Config/Config.php
+++ b/Config/Config.php
@@ -63,6 +63,14 @@ class Config extends MagentoConfig implements ConfigInterface
     /**
      * @inheritDoc
      */
+    public function getDisplayAccount(): string
+    {
+        return $this->getValue(self::XPATH_DISPLAY_ACCOUNT) ?? '';
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function getInstructions()
     {
         return (string)$this->getValue(self::XPATH_INSTRUCTIONS);

--- a/Controller/Adminhtml/Transfer/TestCredentials.php
+++ b/Controller/Adminhtml/Transfer/TestCredentials.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Talopay_Transfer
- * 
+ *
  * @author TaloPay https://talo.com.ar/
  * @license OSL-3.0 https://opensource.org/license/osl-3.0.php
  */
@@ -28,6 +28,12 @@ class TestCredentials extends Action implements HttpPostActionInterface
      */
     public const ADMIN_RESOURCE = 'TaloPay_Transfer::config_talopay_transfer';
 
+    /**
+     * @param Context $context
+     * @param ApiClientInterface $taloApi
+     * @param JsonFactory $resultJsonFactory
+     * @param StripTags $tagFilter
+     */
     public function __construct(
         Context $context,
         private readonly ApiClientInterface $taloApi,
@@ -55,6 +61,7 @@ class TestCredentials extends Action implements HttpPostActionInterface
             $userId = $options[$environment . '_user_id'] ?? '';
             $clientId = $options[$environment . '_client_id'] ?? '';
             $clientSecret = $options[$environment . '_client_secret'] ?? '';
+
             // If the secret is "saved" then we need to recover the value
             if ($clientSecret === ConfigInterface::SAFE_PLACEHOLDER) {
                 $clientSecret = null;
@@ -66,6 +73,7 @@ class TestCredentials extends Action implements HttpPostActionInterface
                 $clientId,
                 $clientSecret,
             );
+
             if ($response) {
                 $result['success'] = true;
             }

--- a/Controller/Transfer/Callback.php
+++ b/Controller/Transfer/Callback.php
@@ -76,7 +76,7 @@ class Callback implements HttpPostActionInterface, CsrfAwareActionInterface
                 throw new LocalizedException(__('There was an error processing your payment.'));
             }
             $order = $this->orderRepository->get($taloPayment['magento']['order_id']);
-            $response = $this->paymentProcessor->execute($order, $paymentId, $taloPayment);
+            $this->paymentProcessor->execute($order, $paymentId, $taloPayment);
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage(), ['exception' => $e]);
         }

--- a/Model/ApiClient.php
+++ b/Model/ApiClient.php
@@ -64,7 +64,6 @@ class ApiClient implements ApiClientInterface
             throw new LocalizedException(__('Invalid response data'));
         } catch (Exception $e) {
             $this->logger->error($e->getMessage(), ['body' => $body, 'request' => $dataPost]);
-
         }
         return null;
     }
@@ -92,10 +91,10 @@ class ApiClient implements ApiClientInterface
      * @throws LocalizedException
      */
     protected function getBearerToken(
-        string $environment = null,
-        string $userId = null,
-        string $clientId = null,
-        string $clientSecret = null
+        ?string $environment = null,
+        ?string $userId = null,
+        ?string $clientId = null,
+        ?string $clientSecret = null
     ) {
         $curlClient = $this->curlFactory->create();
         $environment = $environment ?? $this->config->getEnvironment();

--- a/Model/Config/Source/DisplayAccount.php
+++ b/Model/Config/Source/DisplayAccount.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Talopay_Transfer
+ *
+ * @author TaloPay https://talo.com.ar/
+ * @license OSL-3.0 https://opensource.org/license/osl-3.0.php
+ */
+declare(strict_types = 1);
+
+namespace TaloPay\Transfer\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use TaloPay\Transfer\Api\ConfigInterface;
+
+class DisplayAccount implements OptionSourceInterface
+{
+    /**
+     * Return option arrau
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array_map(function ($item) {
+            return [$item['value'] => $item['label']];
+        }, $this->toOptionArray());
+    }
+
+    /**
+     * Return option array
+     *
+     * @return array[]
+     */
+    public function toOptionArray()
+    {
+        return [
+            [
+                'value' => ConfigInterface::DISPLAY_ACCOUNT_BOTH,
+                'label' => __('Both'),
+            ],
+            [
+                'value' => ConfigInterface::DISPLAY_ACCOUNT_ALIAS,
+                'label' => __('Alias')
+            ],
+            [
+                'value' => ConfigInterface::DISPLAY_ACCOUNT_CVU,
+                'label' => __('CVU')
+            ]
+        ];
+    }
+}

--- a/Observer/CreateStoreOnSave.php
+++ b/Observer/CreateStoreOnSave.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Talopay_Transfer
- * 
+ *
  * @author TaloPay https://talo.com.ar/
  * @license OSL-3.0 https://opensource.org/license/osl-3.0.php
  */
@@ -13,6 +13,8 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
@@ -35,6 +37,7 @@ class CreateStoreOnSave implements ObserverInterface
         readonly private ApiClientInterface $apiClient,
         readonly private StoreManagerInterface $storeManager,
         readonly private LoggerInterface $logger,
+        readonly private ManagerInterface $messageManager,
     ) {
     }
 
@@ -56,6 +59,9 @@ class CreateStoreOnSave implements ObserverInterface
 
         try {
             [$newAppId, $newStoreId] = $this->getStoreData($hostname, $baseUrl);
+            if (!$newStoreId) {
+                throw new LocalizedException(__('The store was not created'));
+            }
             $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT;
             $scopeId = 0;
             if ($observer->getWebsite()) {
@@ -82,6 +88,12 @@ class CreateStoreOnSave implements ObserverInterface
             }
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage(), ['exception' => $e]);
+            $this->messageManager->addErrorMessage(
+                __(
+                    '[TaloPay Transfer] There was an error: %1',
+                    $e->getMessage()
+                )
+            );
             return;
         }
     }

--- a/Processor/NotificationProcessor.php
+++ b/Processor/NotificationProcessor.php
@@ -14,13 +14,13 @@ use TaloPay\Transfer\Api\Data\PaymentProcessorResponseInterface;
 use TaloPay\Transfer\Api\NotificationSenderInterface;
 use TaloPay\Transfer\Api\PaymentProcessorInterface;
 
-readonly class NotificationProcessor implements PaymentProcessorInterface
+class NotificationProcessor implements PaymentProcessorInterface
 {
     /**
      * @param NotificationSenderInterface $notificationSender
      */
     public function __construct(
-        private NotificationSenderInterface $notificationSender,
+        readonly private NotificationSenderInterface $notificationSender,
     ) {
     }
 

--- a/Processor/PaymentProcessor.php
+++ b/Processor/PaymentProcessor.php
@@ -56,6 +56,9 @@ class PaymentProcessor implements PaymentProcessorInterface
         ) {
             throw new LocalizedException(__('Invalid payment information'));
         }
+        if (!isset($taloPayment['transactions'])) {
+            return $previousResult;
+        }
 
         $invoiceMessages = [];
         $notifyAll = $this->config->getNotificationEmailStatus() === NotificationSenderInterface::STATUS_ON_TRANSACTION;

--- a/Processor/PaymentProcessorPool.php
+++ b/Processor/PaymentProcessorPool.php
@@ -15,7 +15,7 @@ use TaloPay\Transfer\Api\Data\PaymentProcessorResponseInterface;
 use TaloPay\Transfer\Api\Data\PaymentProcessorResponseInterfaceFactory;
 use TaloPay\Transfer\Api\PaymentProcessorInterface;
 
-readonly class PaymentProcessorPool implements PaymentProcessorInterface
+class PaymentProcessorPool implements PaymentProcessorInterface
 {
     /**
      * @param PaymentProcessorResponseInterfaceFactory $paymentProcessorResponseFactory
@@ -23,9 +23,9 @@ readonly class PaymentProcessorPool implements PaymentProcessorInterface
      * @param array $handlers
      */
     public function __construct(
-        private PaymentProcessorResponseInterfaceFactory $paymentProcessorResponseFactory,
-        private OrderRepositoryInterface $orderRepository,
-        private array $handlers = [],
+        readonly private PaymentProcessorResponseInterfaceFactory $paymentProcessorResponseFactory,
+        readonly private OrderRepositoryInterface $orderRepository,
+        readonly private array $handlers = [],
     ) {
     }
 

--- a/Processor/StatusProcessor.php
+++ b/Processor/StatusProcessor.php
@@ -73,7 +73,8 @@ class StatusProcessor implements PaymentProcessorInterface
             $previousResult->addComment(__('The order has been overpaid'));
         }
 
-        if ($order->getTotalPaid() < $order->getGrandTotal()) {
+        if (!!$order->getTotalPaid() &&
+            $order->getTotalPaid() < $order->getGrandTotal()) {
             $previousResult->addComment(__(
                 'Partial payment received. Remaining balance: %1',
                 $this->priceHelper->currencyByStore($order->getTotalDue(), $order->getStoreId()),

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "TaloPay Magento 2 Transfer module",
     "type": "magento2-module",
     "license": "OSL-3.0",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "require": {
         "ext-intl": "*",
-        "php": "~8.2||~8.3||~8.4",
+        "php": "~8.1||~8.2||~8.3||~8.4",
         "magento/framework": "*",
         "magento/module-payment": "*"
     },

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -27,8 +27,17 @@
                         <field id="*/*/active">1</field>
                     </depends>
                 </field>
+                <field id="store_id" type="label" showInWebsite="1" showInStore="1" showInDefault="1"
+                       translate="label">
+                    <label>Store ID</label>
+                    <comment>After saving valid credentials, this field should contain the Store ID value.</comment>
+                    <depends>
+                        <field id="*/*/active">1</field>
+                    </depends>
+                </field>
                 <include path="TaloPay_Transfer::system/credentials.xml"/>
                 <include path="TaloPay_Transfer::system/notifications.xml"/>
+                <include path="TaloPay_Transfer::system/success.xml"/>
                 <field id="title" type="text" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
                     <label>Title</label>
                     <depends>

--- a/etc/adminhtml/system/success.xml
+++ b/etc/adminhtml/system/success.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<!--
+/**
+ * Talopay_Transfer
+ *
+ * @author TaloPay https://talo.com.ar/
+ * @license OSL-3.0 https://opensource.org/license/osl-3.0.php
+ */
+ -->
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="success" translate="label" showInWebsite="1" showInStore="1" showInDefault="1">
+        <label>Success Page</label>
+        <depends>
+            <field id="*/*/active">1</field>
+        </depends>
+        <field id="display_account" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Display account</label>
+            <source_model>TaloPay\Transfer\Model\Config\Source\DisplayAccount</source_model>
+        </field>
+    </group>
+</include>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -35,6 +35,9 @@
                     <email_enabled>total</email_enabled>
                     <email_notification_template>payment_other_talopay_transfer_notifications_email_notification_template</email_notification_template>
                 </notifications>
+                <success>
+                    <display_account>alias</display_account>
+                </success>
 
                 <!-- Internal configs -->
                 <model>TaloPay\Transfer\Model\Payment\Transfer</model>

--- a/i18n/es_AR.csv
+++ b/i18n/es_AR.csv
@@ -36,3 +36,4 @@
 "Partial payment received. Remaining balance: %1","Pago parcial recibido. Monto restante: %1"
 "The invoice #%1 was been generated with transaction id %2","Se generó la factura #%1 con el id de transacción %2"
 "The invoice #%1 was generated due to Talo\'s tolerance policy.","Se generó la factura #%1 debido a la política de tolerancia de Talo"
+"Both","Ambos"

--- a/view/base/templates/info/instructions.phtml
+++ b/view/base/templates/info/instructions.phtml
@@ -1,7 +1,7 @@
 <?php
 /**
  * Talopay_Transfer
- * 
+ *
  * @author TaloPay https://talo.com.ar/
  * @license OSL-3.0 https://opensource.org/license/osl-3.0.php
  */
@@ -50,7 +50,7 @@ $specificInfo = $block->getSpecificInformation();
                     </td>
                 </tr>
             <?php endif; ?>
-            <?php if (isset($quote['address']) && !isset($quote['alias'])) : ?>
+            <?php if (isset($quote['address'])) : ?>
                 <tr>
                     <th scope="row"><?= $escaper->escapeHtml(__('CVU')); ?></th>
                     <td>

--- a/view/frontend/templates/order/view/instructions.phtml
+++ b/view/frontend/templates/order/view/instructions.phtml
@@ -1,26 +1,32 @@
 <?php
 /**
  * Talopay_Transfer
- * 
+ *
  * @author TaloPay https://talo.com.ar/
  * @license OSL-3.0 https://opensource.org/license/osl-3.0.php
  */
 
 /** @var \TaloPay\Transfer\Block\Payment\View\Instructions $block */
 /** @var \Laminas\Escaper\EscaperInterface $escaper */
+
+use TaloPay\Transfer\Api\ConfigInterface;
+
+?>
+<?php
+$displayAccount = $block->isDisplayAccount();
 ?>
 <?php if($block->isTaloPayTransferMethod()) : ?>
     <div class="talopay-transfer payment-instructions talo-payment-container">
         <div class="payment-status waiting">
             <div class="payment-status-icon"></div>
             <div class="payment-status-message">
-                <div class="status-message-title"><?= $block->escapeHtml(__('Waiting for payment...')) ?></div>
-                <div class="status-message-description"><?= $block->escapeHtml(__('The order status will be updated once the payment is received')) ?></div>
+                <div class="status-message-title"><?= $escaper->escapeHtml(__('Waiting for payment...')) ?></div>
+                <div class="status-message-description"><?= $escaper->escapeHtml(__('The order status will be updated once the payment is received')) ?></div>
             </div>
         </div>
         <div id="talo-cvu-payment-info" class="payment-info">
             <div class="payment-title"><?= $escaper->escapeHtml(__('Make the payment before %1 to complete your purchase', $block->getExpirationDate())) ?></div>
-            <div class="payment-description"><?= $block->escapeHtml(__('After this deadline, the bank details will expire and your order will be canceled. By transferring the exact amount, your purchase will be automatically confirmed.')) ?></div>
+            <div class="payment-description"><?= $escaper->escapeHtml(__('After this deadline, the bank details will expire and your order will be canceled. By transferring the exact amount, your purchase will be automatically confirmed.')) ?></div>
             <div class="payment-warning">
                 <div class="payment-warning-icon"></div>
                 <div class="payment-warning-message">
@@ -37,28 +43,42 @@
 
             <?php foreach ($block->getTaloQuotes() as $_quote) : ?>
                 <div class="payment-information">
-                    <div class="payment-alias-label"><?= $block->escapeHtml(__('Exclusive alias for this purchase')) ?></div>
-                    <div class="payment-alias-container">
-                        <div class="payment-alias">
-                            <?php if (!empty($_quote['alias'])): ?>
-                                <?= $escaper->escapeHtml(__($_quote['alias'])) ?>
-                            <?php else: ?>
-                                <?= $escaper->escapeHtml(__($_quote['address'])) ?>
-                            <?php endif; ?>
+                    <div class="payment-alias-label"><?= $escaper->escapeHtml(__('Exclusive alias for this purchase')) ?></div>
+                    <?php if($displayAccount === ConfigInterface::DISPLAY_ACCOUNT_ALIAS ||
+                            $displayAccount === ConfigInterface::DISPLAY_ACCOUNT_BOTH): ?>
+                        <div class="payment-alias-container">
+                            <div class="payment-alias"><?= $escaper->escapeHtml($_quote['alias']) ?></div>
+                            <div class="container-talo-cvus">
+                                <button type="button"
+                                        id="talo-cvu-payment-alias-button"
+                                        class="copy-button"
+                                        data-copy="<?= $escaper->escapeHtml($_quote['alias']) ?>">
+                                    <?= $escaper->escapeHtml(__('Copy')) ?>
+                                </button>
+                                <span id="talo-cvu-alias-tooltip" class="talo-cvu-alias-tooltip">
+                                    <?= $escaper->escapeHtml(__('Copied')) ?>
+                                </span>
+                            </div>
                         </div>
-                        <div class="container-talo-cvus">
-                            <button type="button"
-                                    id="talo-cvu-payment-alias-button"
-                                    class="copy-button"
-                                    data-copy="<?= $escaper->escapeHtml(!empty($_quote['alias']) ? $_quote['alias'] : $_quote['address']) ?>">
-                                <?= $block->escapeHtml(__('Copy')) ?>
-                            </button>
-                            <span id="talo-cvu-alias-tooltip" class="talo-cvu-alias-tooltip">
-                                <?= $block->escapeHtml(__('Copied')) ?>
-                            </span>
+                    <?php endif; ?>
+                    <?php if($displayAccount === ConfigInterface::DISPLAY_ACCOUNT_CVU ||
+                            $displayAccount === ConfigInterface::DISPLAY_ACCOUNT_BOTH): ?>
+                        <div class="payment-alias-container">
+                            <div class="payment-alias"><?= $escaper->escapeHtml(__($_quote['address'])) ?></div>
+                            <div class="container-talo-cvus">
+                                <button type="button"
+                                        id="talo-cvu-payment-address-button"
+                                        class="copy-button"
+                                        data-copy="<?= $escaper->escapeHtml($_quote['address']) ?>">
+                                    <?= $escaper->escapeHtml(__('Copy')) ?>
+                                </button>
+                                <span id="talo-cvu-address-tooltip" class="talo-cvu-alias-tooltip">
+                                    <?= $escaper->escapeHtml(__('Copied')) ?>
+                                </span>
+                            </div>
                         </div>
-                    </div>
-                    <div class="payment-amount-label"><?= $block->escapeHtml(__('Exact amount for transfer')) ?></div>
+                    <?php endif; ?>
+                    <div class="payment-amount-label"><?= $escaper->escapeHtml(__('Exact amount for transfer')) ?></div>
                     <div class="payment-amount-container">
                         <div id="talo-cvu-payment-amount" class="payment-amount">
                             <?= $escaper->escapeHtml($block->toCurrency($_quote['amount'])) ?>
@@ -68,10 +88,10 @@
                                     id="talo-cvu-payment-amount-button"
                                     class="copy-button"
                                     data-copy="<?= $escaper->escapeHtml($_quote['amount']) ?>">
-                                <?= $block->escapeHtml(__('Copy')) ?>
+                                <?= $escaper->escapeHtml(__('Copy')) ?>
                             </button>
                             <span id="talo-cvu-amount-tooltip" class="talo-cvu-amount-tooltip">
-                                <?= $block->escapeHtml(__('Copied')) ?>
+                                <?= $escaper->escapeHtml(__('Copied')) ?>
                             </span>
                         </div>
                     </div>


### PR DESCRIPTION
The Store ID field is displayed in the configuration (it cannot be edited) to provide visual confirmation of the existence of that key.

It also adds the possibility (by configuration) of displaying the alias or the CVU (or both) on the success page.
The alias is displayed by default.
    
Code is downgraded to provide compatibility with PHP 8.1 and PHP 8.2, given the reports received from instances running on those versions.